### PR TITLE
Fix map rendering in release builds

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,45 @@
+# Flutter ProGuard Rules for UCRoadWays
+
+# Keep Flutter wrapper
+-keep class io.flutter.app.** { *; }
+-keep class io.flutter.plugin.**  { *; }
+-keep class io.flutter.util.** { *; }
+-keep class io.flutter.view.** { *; }
+-keep class io.flutter.** { *; }
+-keep class io.flutter.plugins.** { *; }
+
+# Keep JSON annotations (for models.dart serialization)
+-keepattributes *Annotation*
+-keepattributes Signature
+-keepattributes InnerClasses
+
+# Keep JSON serializable models
+-keep class com.example.flutter_application_1.** { *; }
+-keepclassmembers class * {
+  @com.google.gson.annotations.SerializedName <fields>;
+}
+
+# Keep all model classes (prevents JSON serialization issues)
+-keep class * implements com.google.gson.JsonSerializer { *; }
+-keep class * implements com.google.gson.JsonDeserializer { *; }
+
+# Geolocator plugin
+-keep class com.baseflow.geolocator.** { *; }
+
+# Permission handler
+-keep class com.baseflow.permissionhandler.** { *; }
+
+# SQLite (for offline maps)
+-keep class org.sqlite.** { *; }
+-keep class net.sqlcipher.** { *; }
+
+# HTTP/Dio networking
+-dontwarn okhttp3.**
+-dontwarn okio.**
+-keep class okhttp3.** { *; }
+-keep class okio.** { *; }
+
+# Keep native methods
+-keepclasseswithmembernames class * {
+    native <methods>;
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Required permissions for map and location services -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+
+    <!-- Optional: For background location tracking (if needed) -->
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
+
     <application
         android:label="flutter_application_1"
         android:name="${applicationName}"


### PR DESCRIPTION
Critical fixes for release build issues:
- Add missing INTERNET permission to main AndroidManifest.xml (was only present in debug/profile manifests)
- Add location permissions (ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION)
- Add network state permission for connectivity checks
- Add background location permission for continuous tracking
- Create ProGuard rules to prevent code shrinking issues

The map failed to load in release builds because the INTERNET permission was only declared in debug/profile manifests but missing from the main manifest, which is used alone in release builds.